### PR TITLE
Added attachment_category_select method and adjust view layout

### DIFF
--- a/app/views/attachments/edit_all.html.erb
+++ b/app/views/attachments/edit_all.html.erb
@@ -21,7 +21,7 @@
     <tr id="attachment-<%= attachment.id %>">
       <td style="vertical-align:top;">
         <%- if attachment.thumbnailable? %>
-        <div class="attachment_categories_column" style="<%= "width:#{(Setting.thumbnails_size.to_i*1.5).to_i}px;" %>">
+        <div class="attachment_categories_column" style="<%= "width:#{(Setting.thumbnails_size.to_i).to_i}px;" %>">
           <%= thumbnail_tag( attachment ) %>
         </div>
         <%- else %>
@@ -36,7 +36,7 @@
       </td>
       <td><%= text_field_tag "attachments[#{attachment.id}][filename]", attachment.filename, :size => 40 %></td>
       <td>
-        <%= text_field_tag "attachments[#{attachment.id}][description]", attachment.description, :size => 80, :placeholder => l(:label_optional_description) %>
+        <%= text_field_tag "attachments[#{attachment.id}][description]", attachment.description, :size => 40, :placeholder => l(:label_optional_description) %>
         <%= javascript_tag "observeAutocompleteField('attachments_#{attachment.id}_description', '#{auto_complete_attachment_descriptions_path(@container.project)}')".html_safe %>
       </td>
     </tr>

--- a/app/views/attachments/edit_all.html.erb
+++ b/app/views/attachments/edit_all.html.erb
@@ -29,8 +29,8 @@
           <%= attachment_category_tag(attachment.attachment_category, :span) %>
         </div>
         <%- end %>
-        <div>
-        <%= attachment_category_select "attachments[#{attachment.id}][attachment_category_id]", attachment_categories, attachment.attachment_category_id, :onchange => "changeCategoryColor(this)" %>
+        <div class="attachment_categories_column">
+          <%= attachment_category_select "attachments[#{attachment.id}][attachment_category_id]", attachment_categories, attachment.attachment_category_id, :onchange => "changeCategoryColor(this)" %>
         </div>
         </div>
       </td>
@@ -44,7 +44,7 @@
   </table>
   </div>
   <p>
-    <%= submit_tag l(:button_save) %><%= submit_tag(l(:button_archive), :name => "archive" )%>
+    <%= submit_tag l(:button_save) %><%= submit_tag(l(:button_archive), :name => "archive", :class => "archive_attachments" )%>
     <%= link_to l(:button_cancel), back_url if back_url.present? %>
   </p>
 <% end %>

--- a/app/views/attachments/edit_all.html.erb
+++ b/app/views/attachments/edit_all.html.erb
@@ -30,7 +30,7 @@
         </div>
         <%- end %>
         <div>
-        <%= select_tag "attachments[#{attachment.id}][attachment_category_id]", options_for_select([['', '']] + attachment_categories, attachment.attachment_category_id), :onchange => "changeCategoryColor(this)" %>
+        <%= attachment_category_select "attachments[#{attachment.id}][attachment_category_id]", attachment_categories, attachment.attachment_category_id, :onchange => "changeCategoryColor(this)" %>
         </div>
         </div>
       </td>

--- a/app/views/attachments/upload.js.erb
+++ b/app/views/attachments/upload.js.erb
@@ -12,7 +12,7 @@
     :div, 
     _attachment_tag + tag(:br) + _category_select,
     {:class => "attachment_categories_column",
-     :style => "width:#{Setting.thumbnails_size.to_i*2}px;float:left;word-break:break-all;"
+     :style => "width:#{Setting.thumbnails_size.to_i}px;float:left;word-break:break-all;"
     }
   )
   

--- a/app/views/attachments/upload.js.erb
+++ b/app/views/attachments/upload.js.erb
@@ -2,12 +2,12 @@
   _all_categories = AttachmentCategory.all.collect { |p| [p.name, p.id]} 
   
   _attachment_tag  = @attachment.thumbnailable? ? thumbnail_tag( @attachment ) : attachment_category_tag( @attachment.attachment_category, :span )
-  _category_select = select_tag( 
-    "attachments[#{j params[:attachment_id]}][attachment_category_id]", 
-    options_for_select( [['', '']] + _all_categories, @attachment.attachment_category_id), 
+  _category_select = attachment_category_select(
+    "attachments[#{j params[:attachment_id]}][attachment_category_id]",
+    _all_categories, @attachment.attachment_category_id,
     :onchange => "changeCategoryColor(this, '#attachments_#{params[:attachment_id]}')"
   )
-      
+  
   _file_or_thumbnail = j content_tag( 
     :div, 
     _attachment_tag + tag(:br) + _category_select,

--- a/assets/stylesheets/redmine_attachment_categories.css
+++ b/assets/stylesheets/redmine_attachment_categories.css
@@ -1,5 +1,7 @@
 div.attachment_categories_column {
     text-align: center;
+    margin-right: 4px;
+    margin-bottom: 4px;
 }
 
 .attachment_category {
@@ -7,8 +9,11 @@ div.attachment_categories_column {
 }
 
 .attachments_fields input.description {
-    margin-left: 4px;
-    width: unset;
+    width: 250px;
+}
+
+span.add_attachment {
+    display: block;
 }
 
 .attachment_category_style_default {
@@ -36,4 +41,13 @@ div.thumbnails div {
 
 input.archive_attachments {
     margin-left: 2px;
+}
+
+@media screen and (max-width: 899px) {
+    div.attachment_categories_column>select {
+        width: unset;
+    }
+    .attachments_fields input.description {
+        margin-right: 16px;
+    }
 }

--- a/assets/stylesheets/redmine_attachment_categories.css
+++ b/assets/stylesheets/redmine_attachment_categories.css
@@ -33,3 +33,7 @@ div.attachment_categories_column {
 div.thumbnails div {
     text-align: center;
 }
+
+input.archive_attachments {
+    margin-left: 2px;
+}

--- a/lib/redmine_attachment_categories/patches/attachments_helper_patch.rb
+++ b/lib/redmine_attachment_categories/patches/attachments_helper_patch.rb
@@ -38,6 +38,20 @@ module RedmineAttachmentCategories
             alias_method_chain :render_api_attachment_attributes, :attachment_category
           end
           
+          # ------------------------------------------------------------------------------#
+          # creates an attachment_category_select
+          # ------------------------------------------------------------------------------#
+          def attachment_category_select(name, choices, selected=nil, options={})
+            if blank_text = options.delete(:blank)
+              choices = [[blank_text.is_a?(Symbol) ? l(blank_text) : blank_text, '']] + choices
+            else
+              choices = [['', '']] + choices
+            end
+            select_tag(name,
+                       options_for_select(choices, selected),
+                       options).html_safe
+          end
+          
         end #base
         
       end #self


### PR DESCRIPTION
Supports #6 and #8.

Changes proposed in this pull request:
- Added `attachment_category_select` method for override purpose on another plugin
- Adjust view layout

@gtt-project/maintainer
