### PR TITLE
Reload attachment categories after deleting a category

### DIFF
--- a/app/controllers/attachment_categories_controller.rb
+++ b/app/controllers/attachment_categories_controller.rb
@@ -94,7 +94,6 @@ class AttachmentCategoriesController < ApplicationController
     rescue Exception => e
       flash[:error] = e.message
     end
-  rescue
     redirect_to attachment_categories_path
   end #def
   


### PR DESCRIPTION
Fixes #19.

Changes proposed in this pull request:
- Reload attachment categories after deleting a category

@gtt-project/maintainer
