### PR TITLE
Limit attachment container_type to Issue and show attachment category tag only from issues view

### DIFF
--- a/app/helpers/attachment_categories_helper.rb
+++ b/app/helpers/attachment_categories_helper.rb
@@ -22,7 +22,7 @@
 module AttachmentCategoriesHelper
 
   def uncategorized_attachments_count
-    Attachment.count - Attachment.where(:attachment_category_id => AttachmentCategory.all.pluck(:id)).count
+    Attachment.where(:container_type => 'Issue').count - Attachment.where(:attachment_category_id => AttachmentCategory.all.pluck(:id)).count
   end
   
 end #module

--- a/app/views/attachment_categories/index.html.erb
+++ b/app/views/attachment_categories/index.html.erb
@@ -43,7 +43,7 @@
     <tr class="<%= cycle("odd", "even") %>">
     <td class="total"><%=l(:label_total)%></td>
     <td class="color"><div>&nbsp;</div></td>
-    <td class="allcount"><%= Attachment.count %></td>
+    <td class="allcount"><%= Attachment.where(:container_type => 'Issue').count %></td>
     <td class="buttons">&nbsp;</td>
     </tr>
     </tbody>

--- a/app/views/attachments/edit_all.html.erb
+++ b/app/views/attachments/edit_all.html.erb
@@ -20,30 +20,32 @@
         <span class="author"><%= attachment.author %>, <%= format_time(attachment.created_on) %></span>
       </td>
     </tr>
-    <tr id="attachment-<%= attachment.id %>">
-      <td style="vertical-align:top;">
-        <%- if attachment.thumbnailable? %>
-        <div class="attachment_categories_column" style="<%= "width:#{(Setting.thumbnails_size.to_i).to_i}px;" %>">
-          <%= thumbnail_tag( attachment ) %>
-        </div>
-        <%- else %>
-        <div class="attachment_categories_column" >
-          <%= attachment_category_tag(attachment.attachment_category, :span) %>
-        </div>
-        <%- end %>
-        <div class="attachment_categories_column">
-          <%= attachment_category_select "attachments[#{attachment.id}][attachment_category_id]", attachment_categories, attachment.attachment_category_id, :onchange => "changeCategoryColor(this)" %>
-        </div>
-        </div>
-      </td>
-      <td><%= text_field_tag "attachments[#{attachment.id}][filename]", attachment.filename, :size => 40 %></td>
-      <td>
-        <%= text_field_tag "attachments[#{attachment.id}][description]", attachment.description, :size => 40, :placeholder => l(:label_optional_description) %>
-        <% if !disable_auto_completes %>
-          <%= javascript_tag "observeAutocompleteField('attachments_#{attachment.id}_description', '#{auto_complete_attachment_descriptions_path(@container.project)}')".html_safe %>
-        <% end %>
-      </td>
-    </tr>
+    <% if true %>
+      <tr id="attachment-<%= attachment.id %>">
+        <td style="vertical-align:top;">
+          <%- if attachment.thumbnailable? %>
+          <div class="attachment_categories_column" style="<%= "width:#{(Setting.thumbnails_size.to_i).to_i}px;" %>">
+            <%= thumbnail_tag( attachment ) %>
+          </div>
+          <%- else %>
+          <div class="attachment_categories_column" >
+            <%= attachment_category_tag(attachment.attachment_category, :span) %>
+          </div>
+          <%- end %>
+          <div class="attachment_categories_column">
+            <%= attachment_category_select "attachments[#{attachment.id}][attachment_category_id]", attachment_categories, attachment.attachment_category_id, :onchange => "changeCategoryColor(this)" %>
+          </div>
+          </div>
+        </td>
+        <td><%= text_field_tag "attachments[#{attachment.id}][filename]", attachment.filename, :size => 40 %></td>
+        <td>
+          <%= text_field_tag "attachments[#{attachment.id}][description]", attachment.description, :size => 40, :placeholder => l(:label_optional_description) %>
+          <% if !disable_auto_completes %>
+            <%= javascript_tag "observeAutocompleteField('attachments_#{attachment.id}_description', '#{auto_complete_attachment_descriptions_path(@container.project)}')".html_safe %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
   <% end %>
   </table>
   </div>

--- a/app/views/attachments/edit_all.html.erb
+++ b/app/views/attachments/edit_all.html.erb
@@ -20,7 +20,9 @@
         <span class="author"><%= attachment.author %>, <%= format_time(attachment.created_on) %></span>
       </td>
     </tr>
-    <% if true %>
+    <% before_uri = URI.parse(request.referer) %>
+    <% before_path = Rails.application.routes.recognize_path(before_uri.path) %>
+    <% if before_path.present? && before_path[:controller] == 'issues' %>
       <tr id="attachment-<%= attachment.id %>">
         <td style="vertical-align:top;">
           <%- if attachment.thumbnailable? %>

--- a/app/views/attachments/upload.js.erb
+++ b/app/views/attachments/upload.js.erb
@@ -1,51 +1,55 @@
-<%-
-  _all_categories = AttachmentCategory.all.collect { |p| [p.name, p.id]} 
-  _disable_auto_completes = Setting['plugin_redmine_attachment_categories']['disable_auto_completes'] == "true"
-  
-  _attachment_tag  = @attachment.thumbnailable? ? thumbnail_tag( @attachment ) : attachment_category_tag( @attachment.attachment_category, :span )
-  _category_select = attachment_category_select(
-    "attachments[#{j params[:attachment_id]}][attachment_category_id]",
-    _all_categories, @attachment.attachment_category_id,
-    :onchange => "changeCategoryColor(this, '#attachments_#{params[:attachment_id]}')"
-  )
-  
-  _file_or_thumbnail = j content_tag( 
-    :div, 
-    _attachment_tag + tag(:br) + _category_select,
-    {:class => "attachment_categories_column",
-     :style => "width:#{Setting.thumbnails_size.to_i}px;float:left;word-break:break-all;"
-    }
-  )
-  
-%>
 var fileSpan = $('#attachments_<%= j params[:attachment_id] %>');
-
 <% if @attachment.new_record? %>
   fileSpan.hide();
   alert("<%= escape_javascript @attachment.errors.full_messages.join(', ') %>");
-  
 <% else %>
+  <% if false %>
+    fileSpan.find('input.token').val('<%= j @attachment.token %>');
+    fileSpan.find('a.remove-upload')
+      .attr({
+        "data-remote": true,
+        "data-method": 'delete',
+        href: '<%= j attachment_path(@attachment, :attachment_id => params[:attachment_id], :format => 'js') %>'
+      })
+      .off('click');
+  <% else %>
+    <%-
+      _all_categories = AttachmentCategory.all.collect { |p| [p.name, p.id]}
+      _disable_auto_completes = Setting['plugin_redmine_attachment_categories']['disable_auto_completes'] == "true"
 
-  fileSpan.find('input.token').val('<%= j @attachment.token %>');
-  fileSpan.find('a.remove-upload') 
-    .attr({
-      "data-remote": true,
-      "data-method": 'delete',
-      "style": "",
-      href: '<%= j attachment_path(@attachment, :attachment_id => params[:attachment_id], :format => 'js') %>'
-    })
-    .off('click');
-    
-  fileSpan.attr("style", "display:inline-block;" );
-  fileSpan.prepend('<%= _file_or_thumbnail %>');
-  fileSpan.find('input.description').attr("id", '<%= "attachments_p#{j params[:attachment_id]}_description" %>');
-  
-  if (!<%= _disable_auto_completes %>) {
-    observeAutocompleteField('<%= "attachments_p#{j params[:attachment_id]}_description" %>', '<%= "#{auto_complete_attachment_descriptions_path}" %>');
-  }
-  changeCategoryColor($('<%= "#attachments_#{j params[:attachment_id]}_attachment_category_id" %>'), '<%= "#attachments_#{params[:attachment_id]}" %>');
+      _attachment_tag  = @attachment.thumbnailable? ? thumbnail_tag( @attachment ) : attachment_category_tag( @attachment.attachment_category, :span )
+      _category_select = attachment_category_select(
+        "attachments[#{j params[:attachment_id]}][attachment_category_id]",
+        _all_categories, @attachment.attachment_category_id,
+        :onchange => "changeCategoryColor(this, '#attachments_#{params[:attachment_id]}')"
+      )
 
-    
+      _file_or_thumbnail = j content_tag(
+        :div,
+        _attachment_tag + tag(:br) + _category_select,
+        {:class => "attachment_categories_column",
+        :style => "width:#{Setting.thumbnails_size.to_i}px;float:left;word-break:break-all;"
+        }
+      )
+    %>
+
+    fileSpan.find('input.token').val('<%= j @attachment.token %>');
+    fileSpan.find('a.remove-upload')
+      .attr({
+        "data-remote": true,
+        "data-method": 'delete',
+        "style": "",
+        href: '<%= j attachment_path(@attachment, :attachment_id => params[:attachment_id], :format => 'js') %>'
+      })
+      .off('click');
+
+    fileSpan.attr("style", "display:inline-block;" );
+    fileSpan.prepend('<%= _file_or_thumbnail %>');
+    fileSpan.find('input.description').attr("id", '<%= "attachments_p#{j params[:attachment_id]}_description" %>');
+
+    if (!<%= _disable_auto_completes %>) {
+      observeAutocompleteField('<%= "attachments_p#{j params[:attachment_id]}_description" %>', '<%= "#{auto_complete_attachment_descriptions_path}" %>');
+    }
+    changeCategoryColor($('<%= "#attachments_#{j params[:attachment_id]}_attachment_category_id" %>'), '<%= "#attachments_#{params[:attachment_id]}" %>');
+  <% end %>
 <% end %>
-
-

--- a/app/views/attachments/upload.js.erb
+++ b/app/views/attachments/upload.js.erb
@@ -3,7 +3,9 @@ var fileSpan = $('#attachments_<%= j params[:attachment_id] %>');
   fileSpan.hide();
   alert("<%= escape_javascript @attachment.errors.full_messages.join(', ') %>");
 <% else %>
-  <% if false %>
+  <% before_uri = URI.parse(request.referer) %>
+  <% before_path = Rails.application.routes.recognize_path(before_uri.path) %>
+  <% if before_path.blank? || before_path[:controller] != 'issues' %>
     fileSpan.find('input.token').val('<%= j @attachment.token %>');
     fileSpan.find('a.remove-upload')
       .attr({


### PR DESCRIPTION
Fixes #24.

Changes proposed in this pull request:
- Limit attachment container_type to Issue in `/attachment_categories` view
- Show attachment category tag only from issues view
  - Wiki and Versions view's attachment category will not be shown.

@gtt-project/maintainer
